### PR TITLE
CRONAPP-1954 - Duplo-clique no menu mobile está indo para HTML

### DIFF
--- a/components/crn-navbar.components.json
+++ b/components/crn-navbar.components.json
@@ -1,5 +1,7 @@
 {
   "name": "crn-navbar",
+  "onDrop": "openEditor",
+  "onDoubleClick": "openEditor",
   "text_pt_BR": "Barra de navegação",
   "text_en_US": "Navbar",
   "class": "adjust-icon mdi mdi-navigation",

--- a/css/cronos.css
+++ b/css/cronos.css
@@ -98,11 +98,8 @@
 
 .progress{
   width: 96%;
-  margin: 10px 2%;
-  padding: 3px;
   text-align: center;
   background-color: #f4f4f4;
-  border: 1px solid #dcdcdc;
   color: #fff;
   border-radius: 20px;
 }


### PR DESCRIPTION
CRONAPP-1954

Duplo-clique no menu mobile está indo para HTML

Solução

Adicionado eventos "onDrop" e "onDoubleClick" no componets.json do menu mobile