### PR TITLE
CRONAPP-2101 - Inclusão da dependência do cronapp-ion-tab-badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "ng-file-upload": "12.2.13",
     "angular-moment": "1.2.0",
     "pace": "HubSpot/pace#v1.0.2",
-    "moment": "2.24.0"
+    "moment": "2.24.0",
+    "cronapp-ion-tab-badge": "1.0.0"
   }
 }

--- a/postupdate.json
+++ b/postupdate.json
@@ -171,6 +171,11 @@
       "file": "index.html",
       "script": "node_modules/cronapp-framework-mobile-js/js/reports/reports.service.js",
       "type": "script"
+    },
+    {
+      "file": "index.html",
+      "script": "node_modules/cronapp-ion-tab-badge/dist/index.js",
+      "type": "script"
     }
   ],
   "removes": [


### PR DESCRIPTION
**Problema:** Badge do componente Abas (mobile) não é atualizado
**Solução:** Criamos uma diretiva que identifica quando o atributo badge do ion-tab é atualizado e faz a alteração do badge da tag link. Incluímos essa diretiva como dependência do cronapp-framework-mobile-js. 