### PR TITLE
CRONAPP-1565 - Relatório não abre em visualização no browser do Android

### DIFF
--- a/js/reports/reports.service.js
+++ b/js/reports/reports.service.js
@@ -50,31 +50,7 @@
     
     // open report
     this.openURLContent = function(url) {
-      var include = function() {
-        var frame = $('<iframe/>');
-        frame.attr('frameborder', 0);
-        var h = parseInt($(window).height());
-        
-        frame.attr('height', h - 200);
-        frame.attr('width', '100%');
-        frame.attr('src', url + "?download=false");
-        var m = $('#reportView .modal-body');
-        if(m.get(0)) {
-          m.html(frame);
-          $('#reportViewContext .modal-dialog').css('width', '95%');
-          setTimeout(function() {
-            console.log('open[#reportViewContext]');
-            $('body').append(context);
-            $('#reportView').modal();
-          }, 100);
-        }
-        else {
-          console.log('wait[#reportViewContext]');
-          setTimeout(include, 200);
-        }
-      }
-      
-      setTimeout(include, 200);
+      openReportOnMobile(url)
     };
     
     this.initializeStimulsoft = function(language) {
@@ -454,6 +430,10 @@
         }
       }.bind(this));
     };
-    
+
+    function openReportOnMobile(url) {
+      window.open(url, '_system');
+    }
+
   });
 }(app));


### PR DESCRIPTION
CRONAPP-1565

Relatório não abre em visualização no browser do Android

Resolução

Abrir o relatório fora do webview para o dispositivo gerenciar como será aberto.