### PR TITLE
CRONAPP-2860 Não é possível selecionar imagem svg no componente imagem

### DIFF
--- a/components/crn-image.components.json
+++ b/components/crn-image.components.json
@@ -8,7 +8,7 @@
   "properties": {
     "src": {
       "type": "projectResource",
-      "resourceType": "image/jpeg,image/gif,image/png",
+      "resourceType": "image/jpeg,image/gif,image/png,image/svg+xml",
       "order": 1
     },
     "xattr-position": {


### PR DESCRIPTION
**Problema:**
IDE não seleciona imagens SVG

**Solução:**
Parametrizado no crn-image o mime type da busca do svg