### PR TITLE
CRONAPP-3451 - Não exibe relatório na APK

### DIFF
--- a/js/reports/reports.service.js
+++ b/js/reports/reports.service.js
@@ -115,7 +115,14 @@
               directoryEntry.getFile(fileName, { create: true }, function (fileEntry) {
                   fileEntry.createWriter(function (fileWriter) {
                       fileWriter.onwriteend = function (e) {
-                        window.open(cordova.file.externalApplicationStorageDirectory + fileName, '_system', 'location=yes');
+                        cordova.plugins.fileOpener2.open(
+                            cordova.file.externalApplicationStorageDirectory + fileName,
+                            'application/pdf', {
+                              error: function (e) {
+                                scope.Notification.error($translate.instant('General.ErrorNotSpecified'), e.message);
+                                console.log('Error status: ' + e.status + ' - Error message: ' + e.message);
+                              }
+                            });
                       };
                       fileWriter.onerror = function (e) {
                         alert(e);


### PR DESCRIPTION
Solução
Substituída chamada windows.open para utilização do plugin file-opener