### PR TITLE
CRONAPP-3350 Atualizar a release para 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cronapp-framework-mobile-js",
-  "version": "2.7.4",
+  "version": "2.9.0",
   "description": "Javascript library for CronApp's projects",
   "main": "cronapp.framework.mobile.js",
   "scripts": {


### PR DESCRIPTION
Solução:
Atualização do npm para 2.9.0 (sem publicação no npm)