### PR TITLE
CRONAPP-3769 - Componente Entrada de Texto Flutuante do Mobile não respeita propriedade label

### DIFF
--- a/lib/ionic/css/ionic.css
+++ b/lib/ionic/css/ionic.css
@@ -7692,19 +7692,25 @@ textarea {
 .item-floating-label {
   display: block;
   background-color: transparent;
-  box-shadow: none; }
-  .item-floating-label .input-label {
-    position: relative;
-    padding: 5px 0 0 0;
-    opacity: 0;
-    top: 10px;
-    -webkit-transition: opacity 0.15s ease-in, top 0.2s linear;
-    transition: opacity 0.15s ease-in, top 0.2s linear; }
-    .item-floating-label .input-label.has-input {
-      opacity: 1;
-      top: 0;
-      -webkit-transition: opacity 0.15s ease-in, top 0.2s linear;
-      transition: opacity 0.15s ease-in, top 0.2s linear; }
+  box-shadow: none; 
+}
+
+.item-floating-label .input-label {
+  position: relative;
+  padding: 5px 0 0 0;
+  opacity: 0;
+  top: 10px;
+  -webkit-transition: opacity 0.15s ease-in, top 0.2s linear;
+  transition: opacity 0.15s ease-in, top 0.2s linear; 
+  display: contents;
+}
+
+.item-floating-label .input-label.has-input {
+  opacity: 1;
+  top: 0;
+  -webkit-transition: opacity 0.15s ease-in, top 0.2s linear;
+  transition: opacity 0.15s ease-in, top 0.2s linear; 
+}
 
 textarea,
 input[type="text"],

--- a/lib/ionic/css/ionic.css
+++ b/lib/ionic/css/ionic.css
@@ -7692,25 +7692,21 @@ textarea {
 .item-floating-label {
   display: block;
   background-color: transparent;
-  box-shadow: none; 
-}
-
-.item-floating-label .input-label {
-  position: relative;
-  padding: 5px 0 0 0;
-  opacity: 0;
-  top: 10px;
-  -webkit-transition: opacity 0.15s ease-in, top 0.2s linear;
-  transition: opacity 0.15s ease-in, top 0.2s linear; 
-  display: contents;
-}
-
-.item-floating-label .input-label.has-input {
-  opacity: 1;
-  top: 0;
-  -webkit-transition: opacity 0.15s ease-in, top 0.2s linear;
-  transition: opacity 0.15s ease-in, top 0.2s linear; 
-}
+  box-shadow: none; }
+  .item-floating-label .input-label {
+    position: relative;
+    padding: 5px 0 0 0;
+    opacity: 0;
+    top: 10px;
+    -webkit-transition: opacity 0.15s ease-in, top 0.2s linear;
+    transition: opacity 0.15s ease-in, top 0.2s linear; 
+    display: contents;
+  }
+    .item-floating-label .input-label.has-input {
+      opacity: 1;
+      top: 0;
+      -webkit-transition: opacity 0.15s ease-in, top 0.2s linear;
+      transition: opacity 0.15s ease-in, top 0.2s linear; }
 
 textarea,
 input[type="text"],


### PR DESCRIPTION
O component entrada de texto flutuante estava com o css do label quebrado.

**Solução:**
Adicionar display: contents; na classe .item-floating-label .input-label no arquivo ionic.css