### PR TITLE
CRONAPP-3798 - Valor não é previamente selecionado

### DIFF
--- a/components/crn-item-select.components.json
+++ b/components/crn-item-select.components.json
@@ -5,8 +5,29 @@
   "class": "adjust-icon mdi mdi-equal-box",
   "wrapper": false,
   "pallete": false,
-  "template": "<option value=\"1\" class=\"\">Value 1</option>",
+  "template": "<option value=\"1\" class=\"\" ng-selected=\"\">Value 1</option>",
   "properties": {
+    "ng-selected": {
+      "removable": false,
+      "displayName_pt_BR": "Selecionado",
+      "displayName_en_US": "selected",
+      "type": "list",
+      "options": [
+        {
+          "key": "",
+          "value_pt_BR": "Não",
+          "value_en_US": "No"
+        },
+        {
+          "key": "true",
+          "value_pt_BR": "Sim",
+          "value_en_US": "Yes"
+        }
+      ],
+      "selector": "ng-selected",
+      "childrenProperty": true,
+      "order": 2
+    },
     "id": {
       "order": 1
     },

--- a/components/templates/combobox.template.html
+++ b/components/templates/combobox.template.html
@@ -1,8 +1,8 @@
 <label class="item item-input item-select">
   <div class="input-label">Select Item</div>
   <select aria-label="Aria Label Text" ng-model="vars.combobox${RANDOM}" id="select-${RANDOM}">
-    <option data-component="crn-item-select" class="active" value="1">Value 1</option>
-    <option data-component="crn-item-select" class="" value="2">Value 2</option>
-    <option data-component="crn-item-select" class="" value="3">Value 3</option>
+    <option data-component="crn-item-select" class="active" value="1" ng-selected="true">Value 1</option>
+    <option data-component="crn-item-select" class="" value="2" ng-selected="">Value 2</option>
+    <option data-component="crn-item-select" class="" value="3" ng-selected="">Value 3</option>
   </select>
 </label>


### PR DESCRIPTION
**Problema**
Componente mobile caixa de seleção não estava aplicando ng-select

**Solução**
Adicionado uma propriedade que lista as opções de ng-select e estabelecendo valor padrão.