### PR TITLE
CRONAPP-3458 - Evento ng-click() não aparece nos eventos do botão mobile

### DIFF
--- a/components/crn-button.components.json
+++ b/components/crn-button.components.json
@@ -15,7 +15,7 @@
     "class": {
       "order": 9999
     },
-    "ng-click": {
+    "onclick": {
       "removable": true,
       "type": "event"
     },


### PR DESCRIPTION
Bug - Evento ao clicar (onclick) não estava cadastrado no componente botão