### PR TITLE
CRONAPP-4110 - Tag HTML aparece em conteúdo do título da caixa de seleção

### DIFF
--- a/components/crn-select.components.json
+++ b/components/crn-select.components.json
@@ -44,7 +44,7 @@
   "childrenProperties": [
     {
       "name": "content",
-      "selector": "div",
+      "selector": "label",
       "displayName_pt_BR": "Título",
       "displayName_en_US": "Title",
       "type": "text"


### PR DESCRIPTION
**Problema**
Tag HTML aparece em conteúdo do título da caixa de seleção.

**Solução**
Trocado o selector do título de div para label.