### PR TITLE
CRONAPP-940 - Propriedade seleção de tamanho de fonte nos componentes visuais de textos

### DIFF
--- a/components/crn-container.components.json
+++ b/components/crn-container.components.json
@@ -4,7 +4,7 @@
   "text_en_US": "Container",
   "image": "/node_modules/cronapp-framework-mobile-js/img/cron-icon/crn-container.svg",
   "wrapper": false,
-  "template": "<div data-replace=\"true\">&nbsp;</div>",
+  "template": "<div data-component=\"crn-container\" data-replace=\"true\">Container</div>",
   "properties": {
     "id": {
       "order": 1

--- a/components/crn-heading.components.json
+++ b/components/crn-heading.components.json
@@ -14,7 +14,7 @@
     },
     "xattr-type": {
       "displayName_pt_BR": "Tamanho da letra",
-      "displayName_en_US": "Lettering size",
+      "displayName_en_US": "Font size",
       "order": 3
     },
     "xattr-position": {

--- a/components/crn-heading.components.json
+++ b/components/crn-heading.components.json
@@ -4,7 +4,7 @@
   "text_en_US": "Title",
   "image": "/node_modules/cronapp-framework-mobile-js/img/cron-icon/crn-text-component.svg",
   "wrapper": false,
-  "template": "<h1 class=\"text-center\" xattr-position=\"text-center\">Title</h1>",
+  "template": "<h1 class=\"text-center h1\" xattr-position=\"text-center\" xattr-type=\"h1\">Title</h1>",
   "properties": {
     "id": {
       "order": 1
@@ -12,12 +12,17 @@
     "class": {
       "order": 9999
     },
+    "xattr-type": {
+      "displayName_pt_BR": "Tamanho da letra",
+      "displayName_en_US": "Lettering size",
+      "order": 3
+    },
     "xattr-position": {
       "displayName_pt_BR": "Posição do texto",
       "displayName_en_US": "Text position",
-      "order": 3
+      "order": 4
     },
-    "content":{
+    "content": {
       "displayName_pt_BR": "Título",
       "displayName_en_US": "Title",
       "order": 2
@@ -70,6 +75,28 @@
           "value_pt_BR": "Direita",
           "value_en_US": "Right",
           "icon": "mdi mdi-ray-end"
+        }
+      ]
+    },
+    {
+      "name": "xattr-type",
+      "type": "options",
+      "target": "class",
+      "values": [
+        {
+          "key": "h1",
+          "value_pt_BR": "Título maior",
+          "value_en_US": "Major Title"
+        },
+        {
+          "key": "h3",
+          "value_pt_BR": "Título médio",
+          "value_en_US": "Medium Title"
+        },
+        {
+          "key": "h5",
+          "value_pt_BR": "Título menor",
+          "value_en_US": "Minor Title"
         }
       ]
     }

--- a/components/crn-paragraph.components.json
+++ b/components/crn-paragraph.components.json
@@ -14,7 +14,7 @@
     },
     "xattr-type": {
       "displayName_pt_BR": "Tamanho da letra",
-      "displayName_en_US": "Lettering size",
+      "displayName_en_US": "Font size",
       "order": 3
     },
     "xattr-position": {
@@ -90,7 +90,7 @@
         {
           "key": "font-size: 25px;",
           "value_pt_BR": "Texto grande",
-          "value_en_US": "Minor text"
+          "value_en_US": "Large text"
         }
       ]
     }

--- a/components/crn-paragraph.components.json
+++ b/components/crn-paragraph.components.json
@@ -4,13 +4,18 @@
   "text_en_US": "Paragraph",
   "image": "/node_modules/cronapp-framework-mobile-js/img/cron-icon/crn-paragraph.svg",
   "wrapper": false,
-  "template": "<p xattr-position=\"text-center\" class=\"text-center\">Some friendly Paragraph</p>",
+  "template": "<p xattr-position=\"text-center\" style=\"font-size: 14px;\" class=\"text-center\" xattr-type=\"font-size: 14px;\">Some friendly Paragraph</p>",
   "properties": {
     "id": {
       "order": 1
     },
     "class": {
       "order": 9999
+    },
+    "xattr-type": {
+      "displayName_pt_BR": "Tamanho da letra",
+      "displayName_en_US": "Lettering size",
+      "order": 3
     },
     "xattr-position": {
       "displayName_pt_BR": "Posição do texto",
@@ -66,6 +71,28 @@
           "icon": "mdi mdi-ray-end"
         }
       ]
+    },
+    {
+      "name": "xattr-type",
+      "type": "options",
+      "target": "style",
+      "values": [
+        {
+          "key": "font-size: 14px;",
+          "value_pt_BR": "Padrão",
+          "value_en_US": "Default"
+        },
+        {
+          "key": "font-size: 18px;",
+          "value_pt_BR": "Texto médio",
+          "value_en_US": "Medium text"
+        },
+        {
+          "key": "font-size: 25px;",
+          "value_pt_BR": "Texto grande",
+          "value_en_US": "Minor text"
+        }
+      ]
     }
   ],
   "childrenProperties": [
@@ -77,9 +104,9 @@
   ],
   "styles": [
     {
-        "selector": "p",
-        "text_pt_BR": "Conteúdo",
-        "text_en_US": "Content"
+      "selector": "p",
+      "text_pt_BR": "Conteúdo",
+      "text_en_US": "Content"
     }
-]
+  ]
 }


### PR DESCRIPTION
**Problema**
Alguns componentes que em sua essência é só texto não apresentava uma forma low-code de alterar o tamanho da fonte.

**Solução**
Adicionado campo low-code (xattr-type) para os componentes

**Componentes corrigidos:**
- Título
- Parágrafo
- Recipiente (adicionado conteúdo para facilitar a localização na tela)