### PR TITLE
CRONAPP-4231 - Título do componente entrada de texto flutuante está fixo

### DIFF
--- a/components/crn-input-floating.components.json
+++ b/components/crn-input-floating.components.json
@@ -5,6 +5,9 @@
   "class": "adjust-icon mdi mdi-label-outline",
   "wrapper": false,
   "templateURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/dist/components/templates/floattextinput.template.html",
+  "designTimeHTMLURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/dist/components/templates/floattextinput.designtime.html",
+  "designTimeSelector": ":self",
+  "designTimeDynamic": true,
   "properties": {
     "id": {
       "order": 1

--- a/components/templates/floattextinput.designtime.html
+++ b/components/templates/floattextinput.designtime.html
@@ -1,0 +1,4 @@
+<label class="item item-input item-floating-label" data-component="crn-input-floating">
+    <span class="input-label has-input">Input Label</span>
+    <input type="text" aria-label="Aria Label Text" placeholder="Input Placeholder" class="ng-valid ng-not-empty ng-dirty ng-valid-parse ng-touched" >
+</label>

--- a/components/templates/floattextinput.template.html
+++ b/components/templates/floattextinput.template.html
@@ -1,4 +1,4 @@
-<div class="item item-input item-floating-label">
+<label class="item item-input item-floating-label">
     <span class="input-label">Input Label</span>
     <input type="text" aria-label="Aria Label Text" placeholder="Input Placeholder" ng-model="vars.input${RANDOM}" mask="" keyboard="">
-</div>
+</label>

--- a/css/app.css
+++ b/css/app.css
@@ -271,3 +271,7 @@ kendo-chat .k-bubble {
 .button-bar > .button:last-child{
     border-right-width: inherit;
 }
+
+.item-floating-label .input-label{
+    display: table;
+}


### PR DESCRIPTION
**Problema**
Título do componente entrada de texto flutuante já é renderizado no formulário sem precisar digitar no campo de entrada.

**Solução**
Ajuste no css e html que estava impedindo o efeito.