### PR TITLE
CRONAPP-4333 - Criar componente de rodapé com ícones para mobile

### DIFF
--- a/components/crn-ion-footer-bar.components.json
+++ b/components/crn-ion-footer-bar.components.json
@@ -4,7 +4,7 @@
   "text_en_US": "Footer",
   "image": "/node_modules/cronapp-framework-mobile-js/img/cron-icon/crn-ion-footer-bar.svg",
   "description": "Estrutura de rodapé com botões",
-  "description_en_US": "Estrutura de rodapé com botões",
+  "description_en_US": "Footer structure with buttons",
   "category": [
       "LAYOUTS"
   ],

--- a/components/crn-tabs-icon-only-item.components.json
+++ b/components/crn-tabs-icon-only-item.components.json
@@ -30,11 +30,6 @@
       "displayName_en_US": "Placeholder",
       "order": 2
     },
-    "class": {
-      "displayName_pt_BR": "Ícone",
-      "displayName_en_US": "Icon",
-      "order": 1
-    },
     "id": {
       "order": 4
     },
@@ -66,19 +61,25 @@
   "childrenProperties": [
     {
       "name": "class",
+      "displayName_pt_BR": "Ícone",
+      "displayName_en_US": "Icon",
       "selector": "i",
       "type": "icon",
       "order": 1
     },
     {
-      "name": "title",
+      "name": "title",      
       "selector": "a",
-      "type": "text"
+      "type": "text",
+      "order": 2
     },
     {
       "name": "content",
+      "displayName_pt_BR": "Título",
+      "displayName_en_US": "Title",
       "selector": "span",
-      "type": "text"
+      "type": "text",
+      "order": 3
     }
   ]
 }

--- a/components/crn-tabs-icon-only-item.components.json
+++ b/components/crn-tabs-icon-only-item.components.json
@@ -6,7 +6,7 @@
   "wrapper": false,
   "autoWrapper": true,
   "pallete": false,
-  "template": "<a class=\"tab-item\" title=\"New tabs\" data-component=\"crn-tabs-icon-only-item\" href=\"\"><i class=\"icon ion-gear-a\"></i></a>",
+  "template": "<a class=\"tab-item\" title=\"New tabs\" data-component=\"crn-tabs-icon-only-item\" contenttitle=\"\" href=\"\"><i class=\"icon ion-gear-a\"></i><span>New tabs</span></a>",
   "controls": {
     "ungroup": false,
     "resizable": false,
@@ -30,11 +30,13 @@
       "displayName_en_US": "Placeholder",
       "order": 2
     },
+    "class": {
+      "displayName_pt_BR": "Ícone",
+      "displayName_en_US": "Icon",
+      "order": 1
+    },
     "id": {
       "order": 4
-    },
-    "class": {
-      "order": 9999
     },
     "ng-click": {
       "removable": false,
@@ -65,14 +67,17 @@
     {
       "name": "class",
       "selector": "i",
-      "displayName_pt_BR": "Ícone",
-      "displayName_en_US": "Icon",
       "type": "icon",
       "order": 1
     },
     {
       "name": "title",
       "selector": "a",
+      "type": "text"
+    },
+    {
+      "name": "content",
+      "selector": "span",
       "type": "text"
     }
   ]

--- a/components/crn-tabs-icon-only.components.json
+++ b/components/crn-tabs-icon-only.components.json
@@ -12,9 +12,6 @@
     "autoWrapper": true,
     "forcedGroup": true,
     "templateURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/components/templates/tabs-icon-only.template.html",
-    "designTimeHTMLURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/components/templates/tabs-icon-only.designtime.html",
-    "designTimeSelector": "ion-tabs",
-    "designTimeDynamic": true,
     "controls": {
         "ungroup": true,
         "resizable": false,

--- a/components/crn-tabs-icon-only.components.json
+++ b/components/crn-tabs-icon-only.components.json
@@ -1,10 +1,10 @@
 {
     "name": "crn-tabs-icon-only",
-    "text_pt_BR": "Abas com ícone",
-    "text_en_US": "Tabs with icon",
+    "text_pt_BR": "Rodapé com ícone",
+    "text_en_US": "Footer with icon",
     "image": "/node_modules/cronapp-framework-mobile-js/img/cron-icon/crn-tabs-icon-only.svg",
-    "description": "Diferentes painéis separados por abas com ícone",
-    "description_en_US": "Different panels separated by tabs with icon",
+    "description": "Estrutura de rodapé com ícones",
+    "description_en_US": "Footer structure with icon",
     "category": [
         "LAYOUTS"
     ],
@@ -52,6 +52,12 @@
             "displayName_pt_BR": "Tamanho dos ícones",
             "displayName_en_US": "Icon size",
             "selector": "i",
+            "order": 3
+        },
+        "tabs-text": {
+            "displayName_pt_BR": "Texto da aba",
+            "displayName_en_US": "Tabs text",
+            "selector": "span",
             "order": 3
         }
     },

--- a/components/crn-tabs-icon-only.components.json
+++ b/components/crn-tabs-icon-only.components.json
@@ -3,11 +3,18 @@
     "text_pt_BR": "Rodapé com ícone",
     "text_en_US": "Footer with icon",
     "image": "/node_modules/cronapp-framework-mobile-js/img/cron-icon/crn-tabs-icon-only.svg",
-    "description": "Estrutura de rodapé com ícones",
-    "description_en_US": "Footer structure with icon",
+    "description": "Rodapé com ícone e título",
+    "description_en_US": "Footer with icon and title",
     "category": [
         "LAYOUTS"
     ],
+    "wrapper": false,
+    "autoWrapper": true,
+    "forcedGroup": true,
+    "templateURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/components/templates/tabs-icon-only.template.html",
+    "designTimeHTMLURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/components/templates/tabs-icon-only.designtime.html",
+    "designTimeSelector": "ion-tabs",
+    "designTimeDynamic": true,
     "controls": {
         "ungroup": true,
         "resizable": false,
@@ -16,10 +23,13 @@
         "pluggable": false,
         "removable": true
     },
-    "wrapper": false,
-    "autoWrapper": true,
-    "forcedGroup": true,
-    "templateURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/components/templates/tabs-icon-only.template.html",
+    "droppableArea": {
+        "onmiddle": true,
+        "ontop": false,
+        "onbottom": false,
+        "onleft": false,
+        "onright": false
+    },
     "properties": {
         "class": {
             "order": 9999
@@ -45,19 +55,13 @@
         "tabs-color": {
             "displayName_pt_BR": "Cor dos ícones",
             "displayName_en_US": "Icon color",
-            "selector": "i",
+            "selector": "tab-item",
             "order": 2
         },
         "tabs-size": {
             "displayName_pt_BR": "Tamanho dos ícones",
             "displayName_en_US": "Icon size",
-            "selector": "i",
-            "order": 3
-        },
-        "tabs-text": {
-            "displayName_pt_BR": "Texto da aba",
-            "displayName_en_US": "Tabs text",
-            "selector": "span",
+            "selector": "tab-item",
             "order": 3
         }
     },
@@ -66,7 +70,7 @@
         "rules": [
             {
                 "activeClass": "active",
-                "sourceHTML": "<a class=\"tab-item\" title=\"New tabs\" data-component=\"crn-tabs-icon-only-item\" href=\"\"><i class=\"icon ion-gear-a\"></i></a>",
+                "sourceHTML": "<a class=\"tab-item\" title=\"New tabs\" data-component=\"crn-tabs-icon-only-item\" contenttitle=\"\" href=\"\"><i class=\"icon ion-gear-a\"></i><span>New tabs</span></a>",
                 "targetSelector": "div.tabs"
             }
         ]

--- a/components/templates/tabs-icon-only.template.html
+++ b/components/templates/tabs-icon-only.template.html
@@ -2,12 +2,15 @@
     <div class="tabs">
         <a class="tab-item active" title="Tabs 1" data-component="crn-tabs-icon-only-item" href="">
             <i class="icon ion-home"></i>
+            <span></span>
         </a>
         <a class="tab-item" title="Tabs 2" data-component="crn-tabs-icon-only-item" href="">
             <i class="icon ion ion-android-add"></i>
+            <span></span>
         </a>
         <a class="tab-item" title="Tabs 3" data-component="crn-tabs-icon-only-item" href="">
             <i class="icon ion-gear-a"></i>
+            <span></span>
         </a>
     </div>
 </ion-tabs>

--- a/components/templates/tabs-icon-only.template.html
+++ b/components/templates/tabs-icon-only.template.html
@@ -4,11 +4,11 @@
             <i class="icon ion-home"></i>
             <span>Home</span>
         </a>
-        <a class="tab-item" title="User" data-component="crn-tabs-icon-only-item" contenttitle="" href="">
+        <a class="tab-item" title="User" data-component="crn-tabs-icon-only-item" href="">
             <i class="icon fa fa-user"></i>
             <span>User</span>
         </a>
-        <a class="tab-item" title="Config" data-component="crn-tabs-icon-only-item" contenttitle="" href="">
+        <a class="tab-item" title="Config" data-component="crn-tabs-icon-only-item" href="">
             <i class="icon ion-gear-a"></i>
             <span>Config</span>
         </a>

--- a/components/templates/tabs-icon-only.template.html
+++ b/components/templates/tabs-icon-only.template.html
@@ -1,16 +1,16 @@
-<ion-tabs class="tabs-striped background-white component-holder icon-size-large tabs-icon-blue" tabs-color="tabs-icon-blue" tabs-size="icon-size-large" background-color="background-white" data-component="crn-tabs-icon-only">
+<ion-tabs class="tabs-striped background-white tabs-icon-blue icon-size-large component-holder" background-color="background-white" tabs-color="tabs-icon-blue" tabs-size="icon-size-large" data-component="crn-tabs-icon-only" id="crn-tabs-icon-only-707450">
     <div class="tabs">
-        <a class="tab-item active" title="Tabs 1" data-component="crn-tabs-icon-only-item" href="">
+        <a class="tab-item active" title="Home" data-component="crn-tabs-icon-only-item" href="">
             <i class="icon ion-home"></i>
-            <span></span>
+            <span>Home</span>
         </a>
-        <a class="tab-item" title="Tabs 2" data-component="crn-tabs-icon-only-item" href="">
-            <i class="icon ion ion-android-add"></i>
-            <span></span>
+        <a class="tab-item" title="User" data-component="crn-tabs-icon-only-item" contenttitle="" href="">
+            <i class="icon fa fa-user"></i>
+            <span>User</span>
         </a>
-        <a class="tab-item" title="Tabs 3" data-component="crn-tabs-icon-only-item" href="">
+        <a class="tab-item" title="Config" data-component="crn-tabs-icon-only-item" contenttitle="" href="">
             <i class="icon ion-gear-a"></i>
-            <span></span>
+            <span>Config</span>
         </a>
     </div>
 </ion-tabs>

--- a/css/app.css
+++ b/css/app.css
@@ -62,8 +62,8 @@
 }
 
 .tabs {
-    height: calc(57px + var(--safe-area-inset-bottom, 19px)) !important;
-    min-height: 57px;
+    height: calc(44px + var(--safe-area-inset-bottom, 19px)) !important;
+    min-height: 44px;
 }
 
 .bar .title + .button:last-child, .bar > .button + .button:last-child, .bar > .button.pull-right, .bar .buttons.pull-right, .bar .title + .buttons {
@@ -289,4 +289,13 @@ kendo-chat .k-bubble {
     font-size: 10px;
     height: 33px;
     margin-top: -16px;
+}
+
+.tabs-striped .tabs {
+    height: calc(57px + var(--safe-area-inset-bottom, 19px)) !important;
+    min-height: 57px;
+}
+
+.has-footer-tabs {
+    bottom: 57px;
 }

--- a/css/app.css
+++ b/css/app.css
@@ -62,11 +62,11 @@
 }
 
 .tabs {
-    height: calc(45px + var(--safe-area-inset-bottom, 19px)) !important;
-    min-height: 49px;
+    height: calc(57px + var(--safe-area-inset-bottom, 19px)) !important;
+    min-height: 57px;
 }
 
-bar .title + .button:last-child, .bar > .button + .button:last-child, .bar > .button.pull-right, .bar .buttons.pull-right, .bar .title + .buttons {
+.bar .title + .button:last-child, .bar > .button + .button:last-child, .bar > .button.pull-right, .bar .buttons.pull-right, .bar .title + .buttons {
     margin-right: calc(5px + var(--safe-area-inset-left));
 }
 
@@ -273,8 +273,20 @@ kendo-chat .k-bubble {
 }
 
 .tabs-striped .tabs .tab-item .icon{
+    display: contents;
+}
+
+.tabs-striped .tabs .tab-item{
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 100%;
+    flex-direction: column;
+}
+
+.tabs-striped .tabs .tab-item span{
+    margin: 0;
+    padding: 0;
+    font-size: 10px;
+    height: 33px;
+    margin-top: -16px;
 }

--- a/css/app.css
+++ b/css/app.css
@@ -276,4 +276,5 @@ kendo-chat .k-bubble {
     display: flex;
     justify-content: center;
     align-items: center;
+    height: 100%;
 }


### PR DESCRIPTION
**Melhoria**
Criação de um componente de rodapé que possibilite a opção de utilizar somente ícone ou ícone com título.