### PR TITLE
CRONAPP-4447 - Componente menu dinâmico não está abrindo ao duplo clique

### DIFF
--- a/components/crn-mobile-menu.components.json
+++ b/components/crn-mobile-menu.components.json
@@ -1,5 +1,7 @@
 {
   "name": "crn-mobile-menu",
+  "onDoubleClick": "openEditor",
+  "onDrop": "openEditor",
   "text_pt_BR": "Menu Dinâmico",
   "text_en_US": "Dynamic Menu",
   "class": "adjust-icon mdi mdi-menu",


### PR DESCRIPTION
**Problema**
O menu do mobile não abre ao duplo clique.

**Solução**
Adicionado tag do components.json que executam essa função.