### PR TITLE
CRONAPP-4514 - Lista avançada está quebrada em produção

### DIFF
--- a/components/crn-ion-list.components.json
+++ b/components/crn-ion-list.components.json
@@ -2,14 +2,6 @@
   "name": "crn-ion-list",
   "text_pt_BR": "Lista Avançada",
   "text_en_US": "Advanced List",
-  "image": "/node_modules/cronapp-framework-mobile-js/img/cron-icon/crn-ion-list.svg",
-  "description": "Lista de dados com barra de pesquisa",
-  "description_en_US": "Data list with search bar",
-  "category": [
-    "LISTS"
-  ],
-  "onDrop": "openEditor",
-  "wrapper": true,
   "onDoubleClick": "openEditor",
   "onDrop": "openEditor",
   "image": "/node_modules/cronapp-framework-mobile-js/img/cron-icon/crn-ion-list.svg",


### PR DESCRIPTION
**Problema:**
Lista avançada não abre painel de configuração.

**Solução:**
Removendo conteúdo duplicado

