### PR TITLE
CRONAPP-4518 - Título do cabeçalho mobile vem descentralizado

### DIFF
--- a/components/templates/ion-header-bar.template.html
+++ b/components/templates/ion-header-bar.template.html
@@ -1,10 +1,10 @@
-<ion-header-bar class="bar bar-positive" data-component="crn-ion-header-bar" xattr-theme="bar-positive">
+<ion-header-bar class="crn-ion-header-bar bar bar-positive" data-component="crn-ion-header-bar" xattr-theme="bar-positive">
   <div class="buttons buttons-left header-item" data-component="crn-header-button" id="crn-header-button-1">
     <button class="button button-clear component-holder" menu-toggle="left">
       <i class="ion ion-android-menu"></i>
     </button>
   </div>
-  <h1 class="title" align-title="text-align: center;" style="text-align: center; left: 40px; right: 40px;">Title!</h1>
+  <h1 class="title" align-title="text-align: center;" style="text-align: center;">Title!</h1>
   <div class="buttons buttons-right header-item" data-component="crn-header-button" id="crn-header-button-2">
     <button class="button button-clear component-holder" menu-toggle="right">
       <i class="ion ion-android-menu"></i>

--- a/css/app.css
+++ b/css/app.css
@@ -304,3 +304,8 @@ ion-header-bar.bar h1.title {
 .tab-content>.active {
     display: block
 }
+
+.crn-ion-header-bar h1.title{    
+    left: 40px; 
+    right: 40px;
+}


### PR DESCRIPTION
**Problema:**
Em projetos antigos o título do cabeçalho não respeita do layout.

**Solução:**
Adicionar classe css para impor a limitação do layout.