### PR TITLE
CRONAPP-4459 - Não é possível adicionar na view Componente Mobile Área de Texto

### DIFF
--- a/components/crn-textarea.components.json
+++ b/components/crn-textarea.components.json
@@ -9,7 +9,7 @@
     "INPUTS", "FORMS"
   ],
   "wrapper": false,
-  "templateURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/dist/compnents/templates/textarea.template.html",
+  "templateURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/dist/components/templates/textarea.template.html",
   "properties": {
     "class": {
       "order": 9999


### PR DESCRIPTION
**Solução:**
Adicionado caracteres faltante no caminho do templateURL