### PR TITLE
CRONAPP-4400 - Cabeçalho sem opções de edição do componente mobile

### DIFF
--- a/components/crn-ion-header-bar.components.json
+++ b/components/crn-ion-header-bar.components.json
@@ -45,7 +45,7 @@
     "additive": false,
     "duplicable": false,
     "pluggable": false,
-    "removable": false
+    "removable": true
   },
   "droppableArea": {
     "onmiddle": true,


### PR DESCRIPTION
**Solução:**
Habilitado opção de remover componente.