### PR TITLE
CRONAPP-4723 - Barra de navegação não abre editor de menu ao clicar no menu dinâmico

### DIFF
--- a/components/crn-navbar.components.json
+++ b/components/crn-navbar.components.json
@@ -7,6 +7,7 @@
   "class": "adjust-icon mdi mdi-navigation",
   "template": "",
   "pallete": false,
+  "forcedGroup": true,
   "properties": {
     "xattr-theme": {
       "displayName": "Theme"


### PR DESCRIPTION
**Solução:**
Forçar o agrupamento do componente para executar o abertura do modal com "forcedGroup": true,