### PR TITLE
CRONAPP-4508 Ação de mudar abas não está funcionando no componente Mobile Abas

### DIFF
--- a/components/crn-ion-segment-item.components.json
+++ b/components/crn-ion-segment-item.components.json
@@ -15,6 +15,9 @@
             "order": 1
         }
     },
+    "handleRules": {
+        "useParentDataComponentRulesOnActive": "crn-ion-segment"
+    },
     "childrenProperties": [
         {
             "name": "class",


### PR DESCRIPTION
**PROBLEMA**
Ação de mudar abas não está funcionando no componente Mobile Abas.
**SOLUÇÃO**
Permitir que as regras de ativação do componente seja as de um componente "parent".