### PR TITLE
CRONAPP-5253 Carrossel mobile não está permitindo edição do texto do slide

### DIFF
--- a/components/crn-slider-item.components.json
+++ b/components/crn-slider-item.components.json
@@ -172,7 +172,16 @@
       "resourceType": "image/jpeg,image/gif,image/png,image/svg+xml",
       "displayName_pt_BR": "Imagem",
       "displayName_en_US": "Image",
-      "selector": "img"
+      "selector": "img",
+      "order": 1
+    },
+    {
+      "name": "content",
+      "selector": "h2",
+      "displayName_pt_BR": "Subtítulo",
+      "displayName_en_US": "Subtitle",
+      "type": "text",
+      "order": 2
     },
     {
       "name": "object-fit",


### PR DESCRIPTION
**PROBLEMA**
Só é possivel alterar o subtitulo desagrupando o componente.
**SOLUÇÃO**
Incluido atributo subtitulo, mesmo nome que estava sendo usado no componete desagrupado.