### PR TITLE
CRONAPP-5254 Carrossel mobile não edita os demais slides

### DIFF
--- a/components/crn-slider-item.components.json
+++ b/components/crn-slider-item.components.json
@@ -9,7 +9,7 @@
   "forcedGroup": true,
   "properties": {
     "id": {
-      "order": 2
+      "order": 1
     },
     "class": {
       "order": 9999

--- a/components/crn-slider.components.json
+++ b/components/crn-slider.components.json
@@ -8,11 +8,12 @@
   "category": [
     "LAYOUTS"
   ],
-  "wrapper": false,
+  "wrapper": true,
   "templateURL": "src/main/mobileapp/www/node_modules/cronapp-framework-mobile-js/dist/components/templates/slider.template.html",
+  "forcedGroup": true,
   "properties": {
     "id": {
-      "order": 2
+      "order": 1
     },
     "class": {
       "order": 9999


### PR DESCRIPTION
**PROBLEMA**
Não é possivel selecionar/adcionar/remover item do carrosel pela componente sem usar a navegação.
**SOLUÇÃO**
Configurado para no clique do componente, o pai ser selecionado, apresentando a lista dos itens para alterações do filhos.
